### PR TITLE
Enforce opposite-gender spouse relationships

### DIFF
--- a/src/ChurchManagement.Domain/Entities/Member.cs
+++ b/src/ChurchManagement.Domain/Entities/Member.cs
@@ -34,7 +34,7 @@ public class Member : Entity
         BirthDate = birthDate;
         MembershipDate = membershipDate;
         Gender = gender;
-        
+
         // Default permission for new members
         _permissions.Add(PermissionType.Member);
     }
@@ -58,7 +58,7 @@ public class Member : Entity
         BaptizedDate = baptizedDate;
         Email = email;
         PhoneNumber = phoneNumber;
-        
+
         // Default permission for reconstituted members
         _permissions.Add(PermissionType.Member);
     }
@@ -107,6 +107,9 @@ public class Member : Entity
 
     public void SetSpouse(Member? spouse)
     {
+        if (spouse != null && spouse.Gender == Gender)
+            throw new InvalidOperationException("Spouse must be of the opposite gender.");
+
         // Remove existing spouse relationship
         if (Spouse != null && Spouse.Spouse == this)
         {
@@ -165,9 +168,9 @@ public class Member : Entity
         if (string.IsNullOrWhiteSpace(groupName))
             return;
 
-        var itemToRemove = _groups.FirstOrDefault(g => 
+        var itemToRemove = _groups.FirstOrDefault(g =>
             string.Equals(g, groupName.Trim(), StringComparison.OrdinalIgnoreCase));
-        
+
         if (itemToRemove != null)
         {
             _groups.Remove(itemToRemove);

--- a/tests/ChurchManagement.Domain.Tests/MemberTests.cs
+++ b/tests/ChurchManagement.Domain.Tests/MemberTests.cs
@@ -1,0 +1,30 @@
+using ChurchManagement.Domain.Entities;
+using ChurchManagement.Domain.Enums;
+
+namespace ChurchManagement.Domain.Tests;
+
+public class MemberTests
+{
+    [Fact]
+    public void SetSpouse_WithOppositeGender_SetsSpouseForBoth()
+    {
+        var john = new Member("John", "Doe", new DateOnly(1990, 1, 1), new DateOnly(2020, 1, 1), Gender.Male);
+        var jane = new Member("Jane", "Smith", new DateOnly(1991, 2, 2), new DateOnly(2021, 2, 2), Gender.Female);
+
+        john.SetSpouse(jane);
+
+        Assert.Equal(jane, john.Spouse);
+        Assert.Equal(john, jane.Spouse);
+    }
+
+    [Fact]
+    public void SetSpouse_WithSameGender_ThrowsInvalidOperationException()
+    {
+        var alice = new Member("Alice", "Jones", new DateOnly(1992, 3, 3), new DateOnly(2022, 3, 3), Gender.Female);
+        var beth = new Member("Beth", "Brown", new DateOnly(1993, 4, 4), new DateOnly(2023, 4, 4), Gender.Female);
+
+        Assert.Throws<InvalidOperationException>(() => alice.SetSpouse(beth));
+        Assert.Null(alice.Spouse);
+        Assert.Null(beth.Spouse);
+    }
+}


### PR DESCRIPTION
## Summary
- block assigning a spouse of the same gender and enforce opposite-gender requirement
- add tests covering valid spouse assignment and rejection of same-gender spouse

## Testing
- `dotnet test`
- `dotnet test tests/ChurchManagement.Domain.Tests/ChurchManagement.Domain.Tests.csproj --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_68afaad38720832d9e9e4b16b8038fc1