### PR TITLE
Enforce opposite-gender spouse relationships

### DIFF
--- a/src/ChurchManagement.Domain/Entities/Member.cs
+++ b/src/ChurchManagement.Domain/Entities/Member.cs
@@ -77,6 +77,9 @@ public class Member : Entity
 
     public void UpdateGender(Gender gender)
     {
+        if (Spouse != null && Spouse.Gender == gender)
+            throw new InvalidOperationException("Spouse must be of the opposite gender.");
+
         Gender = gender;
         UpdateTimestamp();
     }

--- a/tests/ChurchManagement.Domain.Tests/MemberTests.cs
+++ b/tests/ChurchManagement.Domain.Tests/MemberTests.cs
@@ -27,4 +27,18 @@ public class MemberTests
         Assert.Null(alice.Spouse);
         Assert.Null(beth.Spouse);
     }
+
+    [Fact]
+    public void UpdateGender_WithSpouseOfSameGender_ThrowsInvalidOperationException()
+    {
+        var john = new Member("John", "Doe", new DateOnly(1990, 1, 1), new DateOnly(2020, 1, 1), Gender.Male);
+        var jane = new Member("Jane", "Smith", new DateOnly(1991, 2, 2), new DateOnly(2021, 2, 2), Gender.Female);
+
+        john.SetSpouse(jane);
+
+        Assert.Throws<InvalidOperationException>(() => john.UpdateGender(Gender.Female));
+        Assert.Equal(Gender.Male, john.Gender);
+        Assert.Equal(jane, john.Spouse);
+        Assert.Equal(john, jane.Spouse);
+    }
 }


### PR DESCRIPTION
## Summary
- guard gender updates from creating same-gender spouse pairings
- test that gender changes conflicting with spouse are rejected

## Testing
- `dotnet test`
- `dotnet test tests/ChurchManagement.Domain.Tests/ChurchManagement.Domain.Tests.csproj --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_68afaf404820832d8b543821343fb28a